### PR TITLE
Added a benchmark library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
     "description": "Fast event manager, simples and regex based",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^4.0"
+        "phpunit/phpunit": "^4.0",
+        "wdalmut/php-bench": "*",
+        "zendframework/zend-eventmanager": "~2"
     },
     "license": "MIT",
     "authors": [

--- a/tests/EventManagerTest.php
+++ b/tests/EventManagerTest.php
@@ -65,4 +65,24 @@ class EventManagerTest extends PHPUnit_Framework_TestCase
         $listeners = PHPUnit_Framework_Assert::readAttribute($eventManager, 'listeners');
         $this->assertCount(2, $listeners['post-save']);
     }
+
+    public function benchmarkTriggerAValidCallback($b)
+    {
+        $eventManager = new EventManager();
+        $eventManager->attach("post-save", function ($assert) {});
+
+        for ($i=0; $i<$b->times(); $i++) {
+            $eventManager->trigger("/post-save/", ["override"]);
+        }
+    }
+
+    public function benchmarkZendFrameworkEventManager($b)
+    {
+        $eventManager = new \Zend\EventManager\EventManager();
+        $eventManager->attach("post-save", function ($assert) {});
+
+        for ($i=0; $i<$b->times(); $i++) {
+            $eventManager->trigger("post-save", $this, ["override"]);
+        }
+    }
 }


### PR DESCRIPTION
Just in order to compare the library performance results
#2 This could be useful for compare the library performances

Actually on my laptop

``` sh
FastEventManagerTest\EventManagerTest::benchmarkTriggerAValidCallback      65536 1.326 us/op
```

Just use

```
./vendor/bin/php-bench run tests
```
